### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ jupyter nbextensions install --py --sys-prefix nbgoogleanalytics
 You can then enable it with:
 
 ```bash
-jupyter nbextensions enable --py --sys-prefix nbgoogleanalytics
-jupyter serverextensions enable --sys-prefix nbgoogleanalytics
+jupyter nbextension enable --py --sys-prefix nbgoogleanalytics
+jupyter serverextension enable --sys-prefix nbgoogleanalytics
 ```
 ## Configuration
 


### PR DESCRIPTION
use `jupyter nbextension` instead of `jupyter nbextensions`
use `jupyter serverxtension` instead of `jupyter serverextensions`

These are the commands that worked for me. Are the commands with an `s`-suffix a typo or from an older version of Jupyter?